### PR TITLE
Added clarification to PostExtraData

### DIFF
--- a/devs/backend-api.md
+++ b/devs/backend-api.md
@@ -307,7 +307,7 @@ More info on the request [here](https://github.com/bitclout/backend/blob/47bcc8a
 | Title | string | \(optional\) |
 | BodyObj | json | {Body: STRING, ImageURLs: \[\]} |
 | RecloutedPostHashHex | string | \(optional\) hash of post to modify |
-| PostExtraData | json | \(optional\) extra data |
+| PostExtraData | json | \(optional\) extra data, values must be strings |
 | IsHidden | bool |  |
 | MinFeeRateNanosPerKB | uint64 | Rate per KB |
 


### PR DESCRIPTION
When using `submit-post`, the `PostExtraData` field accepts a json struct which only allows String values.
In the backend, the json provided in `PostExtraData` is mapped to `map[string]string`, making it so all json values must be a string

For example, `PostExtraData: {"MyValue": true}` would error.
This should be reflected in docs, as it can cause unnecessary confusion when using the field.

(Dev Note: Why is this only mapped to strings anyway? Though I assume this is for type simplicity, it'd make much more sense to accept strings, bools, and ints in these fields. We should SERIOUSLY consider creating a spec for the ExtraData field in TXs, as I feel it's going to get messy very quickly as more and more applications are built. Universal fields such as [`Source`](https://github.com/bitclout/core/issues/32) could be very valuable, and I'm sure we could come together and brainstorm a full specific spec for such field.)