### PR TITLE
make things run on the first try

### DIFF
--- a/code/dev-setup.md
+++ b/code/dev-setup.md
@@ -45,7 +45,7 @@ npm install
 # The following command will serve the frontend on localhost:4200 with
 # auto-reloading on changes. You must run a node before the site will
 # actually work however (see next section).
-npx ng serve
+npm start
 ```
 
 ### Running the node in testnet mode

--- a/code/dev-setup.md
+++ b/code/dev-setup.md
@@ -8,6 +8,8 @@ To run the frontend repo, you will need to be running Node v13.13.0 and NPM 6.14
 
 We will also assume that you have [Goland](https://www.jetbrains.com/go/) installed. This is the recommended IDE for developing on DeSo since most of the code is Go code.
 
+Another prerequisite is [vips](https://github.com/libvips/libvips) which can be installed with [homebrew](https://brew.sh/) – `brew install vips` – or `apt install libvips-tools` on Ubuntu.
+
 ## Setup
 
 First, you must checkout all repos into the same directory. Some of these repos are technically optional, but checking them all out allows you to hop around the code more easily.
@@ -43,7 +45,7 @@ npm install
 # The following command will serve the frontend on localhost:4200 with
 # auto-reloading on changes. You must run a node before the site will
 # actually work however (see next section).
-ng serve
+npx ng serve
 ```
 
 ### Running the node in testnet mode
@@ -59,6 +61,7 @@ cd backend/scripts/nodes
 # in the arguments. This gives you funds that you can test with. You can see 
 # the status of the node by going to the Admin tab after logging in with an
 # account and then going to the Network subtab.
+export CGO_CFLAGS_ALLOW="-Xpreprocessor"
 ./n0_test
 
 # Once n0_test is running, you must navigate to the following URL. 4200 is the


### PR DESCRIPTION
Maybe you'd prefer the install scripts to be revised instead? But these additions are what I had to do to get started on MacOS.

1) the `ng` command doesn't work for me after `npm install`, but `npx ng` finds it.
2) a required flag that I found [here](https://github.com/h2non/bimg/issues/330#issuecomment-629051552)
3) a missing dependency (vips)