### PR TITLE
Updated node reqs

### DIFF
--- a/for-node-operators/node-setup/requirements.md
+++ b/for-node-operators/node-setup/requirements.md
@@ -10,11 +10,10 @@ Before running a node check your computer to verify the correct software and har
 
 There is no strict minimum spec to run a DeSo Node, but to ensure optimal performance we recommend:
 
-**CPU:** 8 cores, or more
+**RAM:** 30gb (Regular sync), 64gb (Hypersync), 10gb (Without TxIndex)
+  * Reccomendations based on usage during initial sync; Operational usage 
 
-**RAM:** 32gb, or more
-
-**Disk Space:** 400gb, or more
+**Disk Space:** 500gb
 
 ### Software
 


### PR DESCRIPTION
- Updated memory recommendations to include hypersync & no TxIndex
    - Hyperscync will OOM without at *least* 50gb mem on sync, so 64 is my recommendation
    - I've synced with no TxIndex on 8gb, so 10 should be fine
    - I think 32 for reg sync is way more than needed, but most machines won't come in 20-25 anyway, so 30 should be fine here

- The chain takes up close to 450gb storage (at least when using Docker volume), so 500 should be good for now. This should be progressively updated though

- Not sure where the CPU core recommendation came from, but I've run nodes on as little as one core; concurrency doesn't seem too too important here. I think it's more about the type of core, not the number; this is the spec I have the least data on, though

NOTE: These reqs can heavily change based on external factors (I.e better Disk I/O will result in less memory usage), so although these figures are based on my personal experience running nodes (Which is quite a lot), insight from other operators would be appreciated 