### PR TITLE
Update social-transactions-api.md - Noting that IsHidden is ignored on CREATE

### DIFF
--- a/deso-backend/construct-transactions/social-transactions-api.md
+++ b/deso-backend/construct-transactions/social-transactions-api.md
@@ -161,7 +161,7 @@ extra data, values must be strings. This is an arbitrary json object that can be
 {% endswagger-parameter %}
 
 {% swagger-parameter in="body" name="IsHidden" type="Boolean" required="false" %}
-When true, this post will be hidden
+When true, this post will be hidden. You can't hide a post when creating it, you must submit a second transaction to hide the post.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="body" required="true" name="MinFeeRateNanosPerKB" type="uint64" %}


### PR DESCRIPTION
When true, this post will be hidden. You can't hide a post when creating it, you must submit a second transaction to hide the post.

Source reference: https://github.com/deso-protocol/core/blob/e2587671948fd02c5d4f7661508480822c7b27f3/lib/block_view_post.go#L1030